### PR TITLE
Fix for Multiset#include? with ruby 2.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'rubygems/specification'
 spec = eval(File.read('multimap.gemspec'))
 
 if spec.has_rdoc
-  require 'rake/rdoctask'
+  require 'rdoc/task'
 
   Rake::RDocTask.new { |rdoc|
     rdoc.options = spec.rdoc_options

--- a/lib/multiset.rb
+++ b/lib/multiset.rb
@@ -18,7 +18,7 @@ class Multiset < Set
   end
 
   def include?(e)
-    @hash[e] != 0
+    @hash.include?(e)
   end
 
   # Returns the number of times an element belongs to the multiset.

--- a/lib/multiset.rb
+++ b/lib/multiset.rb
@@ -17,6 +17,10 @@ class Multiset < Set
     super
   end
 
+  def include?(e)
+    @hash[e] != 0
+  end
+
   # Returns the number of times an element belongs to the multiset.
   def multiplicity(e)
     @hash[e]

--- a/multimap.gemspec
+++ b/multimap.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |s|
   s.email    = 'josh@joshpeek.com'
   s.homepage = 'http://github.com/doxavore/multimap'
   s.license  = 'MIT'
+
+  s.add_development_dependency 'rspec', '< 2.0'
 end


### PR DESCRIPTION
`Multiset` depends on `Set` and the implementation of `Set#include?` changed from returning `@hash.include?(e)` in ruby 2.2 to returning `@hash[e]` in ruby 2.3.

Tests for this gem are written for a really old version of rspec, so specify that to verify that tests pass with the change.

Also update the require for the `rdoc` task.

Prime: @fgarces